### PR TITLE
Added dark theme for random background images

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,8 +40,8 @@ main {
 time, .ampm {
   display: inline-block;
   font-size: 4rem;
-  color: rgb(255, 255, 255);
- 
+  color: white;
+  text-shadow: 5px 3px 10px #00000075;
   z-index: 5;
   flex-grow: 1;
   margin: 20px 20px 20px 20px;

--- a/style.css
+++ b/style.css
@@ -23,20 +23,29 @@ main {
   min-height: 100vh;
   margin: 0 auto;
   flex-wrap: wrap;
+  height: 50px;
 }
 
 .clock {
   align-self: center;
+  background-color:rgb(0, 0, 0);
+   
+    opacity: .5;
+      border-radius: 20px;
+  
+    
+    
 }
 
 time, .ampm {
   display: inline-block;
   font-size: 4rem;
-  color: white;
-  text-shadow: 5px 3px 10px #00000075;
+  color: rgb(255, 255, 255);
+ 
   z-index: 5;
   flex-grow: 1;
-  margin: auto 0;
+  margin: 20px 20px 20px 20px;
+
 }
 
 time {


### PR DESCRIPTION
As the background images keep on changing 
for some background images, the timer is not seethrough properly( especially for white color backdrops)
After:
![image](https://user-images.githubusercontent.com/106906121/194536319-60d888ca-6fe7-4f64-a653-638275b727ca.png)
 @NisooJadhav if you liked my contribution pls label with hacktoberfest-accepted